### PR TITLE
Add rsync-based uploader, Add protection against disk space exhaustion

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ in progress
 ===========
 
 - Use 5 minutes recording chunk size as default
+- Protect against running out of disk space
 
 
 2021-06-20 0.2.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Saraswati changelog
 in progress
 ===========
 
+- Use 5 minutes recording chunk size as default
+
 
 2021-06-20 0.2.0
 ================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ in progress
 
 - Use 5 minutes recording chunk size as default
 - Protect against running out of disk space
+- Add uploader based on ``rsync``
 
 
 2021-06-20 0.2.0

--- a/README.rst
+++ b/README.rst
@@ -150,6 +150,17 @@ Display segment metadata information embedded into the file::
     |  + Default duration: 00:00:00.104489796 (9.570 frames/fields per second for a video track)
 
 
+Uploading audio
+===============
+
+When the ``--upload=`` option is given, Saraswati will attempt to upload
+its spool directory to an rsync target. By default, it will do this each
+5 minutes.
+
+Please note ``rsync`` will be invoked using the ``--remove-source-files``
+option. So, after successful upload, the spooled files on the local machine
+will get purged.
+
 
 *******************
 Project information

--- a/automaticRsync.sh
+++ b/automaticRsync.sh
@@ -1,5 +1,0 @@
-while [ true ]; do
-	sleep 10
-		sudo find /var/spool/saraswati/ -not -newermt '-25 seconds' -exec rm -rf {} \;
-			sudo rsync -rv -e 'ssh -p <port> -i <path-to-key>' /var/spool/saraswati/ <server-address>
-			  done

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+# https://docs.codecov.io/docs/common-recipe-list
+# https://docs.codecov.io/docs/commit-status#patch-status
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto   # the required coverage value
+        threshold: 4%  # the leniency in hitting the target
+    patch:
+      default:
+        target: 0%
+        informational: true

--- a/doc/backlog.rst
+++ b/doc/backlog.rst
@@ -2,12 +2,30 @@
 Saraswati backlog
 #################
 
+
+******
+Prio 1
+******
 - [x] Make all parameters configurable
 - [x] Add command line interface
-- [o] Upload files and purge from local disk
-- [o] Record for a maximum number of settings, using GSt's ``num-buffers=``
-- [o] What about ``muxer.audio_1``?
+- [x] Use default chunk size of 5 minutes
+- [x] Upload files and purge from local disk
 - [o] Run as system daemon
+- [o] Document how to use a RAM disk for buffering
+- [o] Improve documentation re. disk storage
+- [o] What about ``muxer.audio_1``?
+- [o] Record for a maximum number of seconds, using GSt's ``num-buffers=``
+
+
+******
+Prio 2
+******
 - [o] Realtime statistics
 - [o] Detect silence
-- [o] Use default chunk size of 5 minutes
+- [o] PTH - inverted PTT
+- [o] Signaling with MQTT
+- [o] PTH from machine and browser
+- [o] Add support for WavPack
+  - https://community.hiveeyes.org/t/developing-saraswati-a-robust-multi-channel-audio-recording-transmission-and-storage-system/924/19
+  - https://gstreamer.freedesktop.org/documentation/wavpack/wavpackenc.html
+- [o] Hardware device auto-discovery

--- a/saraswati/cli.py
+++ b/saraswati/cli.py
@@ -71,7 +71,7 @@ channels_opt = click.option(
     multiple=True,
     callback=validate_channel,
     help="Define channels to record, add multiple times to define more channels. "
-         "The expression to define an audio source should be a GStreamer pipeline element syntax.",
+    "The expression to define an audio source should be a GStreamer pipeline element syntax.",
 )
 spool_opt = click.option(
     "--spool",
@@ -187,4 +187,5 @@ def record(
         recorder.add_channel(name=channel.name, source=channel.source)
 
     # Invoke recording pipelines.
-    recorder.run()
+    recorder.start()
+    recorder.record()

--- a/saraswati/cli.py
+++ b/saraswati/cli.py
@@ -148,7 +148,7 @@ def cli(ctx):
     "--chunk-duration",
     type=click.INT,
     help="Duration of each chunk file (seconds)",
-    default=60,
+    default=5 * 60,
 )
 @click.option(
     "--chunk-max-files",

--- a/saraswati/model.py
+++ b/saraswati/model.py
@@ -19,7 +19,7 @@ class SaraswatiSettings:
     channels: List[Channel]
 
     # Chunking options.
-    chunk_duration: Optional[int] = 10
+    chunk_duration: Optional[int] = 5 * 60
     chunk_max_files: Optional[int] = 9999
 
     # Where to store the recordings.

--- a/saraswati/model.py
+++ b/saraswati/model.py
@@ -30,7 +30,7 @@ class SaraswatiSettings:
 
     # Where and how often to upload recordings.
     upload_target: Optional[str] = None
-    upload_interval: Optional[int] = None
+    upload_interval: Optional[int] = 5 * 60
 
     def __post_init__(self):
         if self.spool_path is not None:

--- a/saraswati/model.py
+++ b/saraswati/model.py
@@ -23,7 +23,7 @@ class SaraswatiSettings:
     chunk_max_files: Optional[int] = 9999
 
     # Where to store the recordings.
-    spool_path: Optional[Path] = None
+    spool_path: Optional[str] = None
     spool_filename_pattern: Optional[
         str
     ] = "recording_{channel}_{timestamp}_{fragment:04d}.mka"

--- a/saraswati/recorder.py
+++ b/saraswati/recorder.py
@@ -151,6 +151,8 @@ class SaraswatiRecorder(threading.Thread):
 
         # Pipeline: Use FLAC encoder and Matroska container.
         # TODO: What about `muxer.audio_1`?
+        # TODO: Add WavPack (wavpackenc)
+        #       https://gstreamer.freedesktop.org/documentation/wavpack/wavpackenc.html
         pipeline_expression = (
             f"{source} ! audioconvert ! queue ! flacenc ! flactag ! flacparse ! "
             f"muxer.audio_0 splitmuxsink name=muxer muxer=matroskamux "

--- a/saraswati/uploader.py
+++ b/saraswati/uploader.py
@@ -1,0 +1,110 @@
+import io
+import logging
+import shlex
+import subprocess
+import sys
+import threading
+import time
+from io import BufferedWriter
+
+import teetime
+
+from saraswati.model import SaraswatiSettings
+
+logger = logging.getLogger(__name__)
+
+
+class SaraswatiUploader(threading.Thread):
+
+    # File with modification time lower than this duration will not be picked up (seconds).
+    PICKUP_AGE_THRESHOLD = 25
+
+    # Which network bandwidth to use when uploading (kB/second).
+    BANDWIDTH_MAX = 80
+
+    # Set network I/O timeout in seconds.
+    IO_TIMEOUT = 15
+
+    def __init__(self, settings: SaraswatiSettings):
+        super().__init__()
+        logger.info("Setting up uploader")
+        self.settings = settings
+
+    def start(self):
+        if self.settings.upload_target is None:
+            logger.info("No upload target, skipping uploader")
+
+        if not self.settings.upload_target.startswith("rsync://"):
+            message = f"Unknown upload target protocol: {self.settings.upload_target}"
+            logger.error(message)
+            raise NotImplementedError(message)
+
+        super().start()
+
+    def run(self):
+        logger.info("Starting uploader")
+        while True:
+            try:
+                self.upload()
+            except:
+                logger.exception("Error while uploading")
+            logger.info(
+                f"The next upload will be in {self.settings.upload_interval} seconds"
+            )
+            time.sleep(self.settings.upload_interval)
+
+    def upload(self):
+        logger.info("Uploading data")
+        target = self.settings.upload_target
+        if target.startswith("rsync://"):
+            target = target.replace("rsync://", "")
+
+            # Only use files which recently have not been written to.
+            find = f"""
+find "{self.settings.spool_path}" -type f 
+    -not -newermt '-{self.PICKUP_AGE_THRESHOLD} seconds' 
+    -exec basename {{}} \;""".strip()
+
+            # Command for uploading selected files.
+            # TODO: Starting with `rsync 3.2.3` (6 Aug 2020), there will be the `--mkpath` option.
+            # https://stackoverflow.com/a/65435579
+            rsync = f"""
+rsync 
+    --archive --update --verbose 
+    --remove-source-files --files-from=- 
+    --bwlimit={self.BANDWIDTH_MAX} --timeout={self.IO_TIMEOUT} 
+    "{self.settings.spool_path}" 
+    {target}""".strip()
+
+            # Reporting.
+            logger.debug(f"Invoking command:\n{find}\n|\n{rsync}")
+
+            # Run two commands, connected with pipes.
+            finder = subprocess.Popen(shlex.split(find), stdout=subprocess.PIPE)
+            finder.wait(timeout=20)
+
+            # Run rsyncer
+            # rsyncer = subprocess.Popen(shlex.split(rsync), stdin=finder.stdout, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+            # Run rsyncer, with tee feature.
+            buffer_stdout = io.BytesIO()
+            buffer_stderr = io.BytesIO()
+            rsyncer = teetime.popen_call(
+                shlex.split(rsync),
+                stdin=finder.stdout,
+                stdout=(sys.stdout.buffer, buffer_stdout),
+                stderr=(sys.stderr.buffer, buffer_stderr),
+            )
+            rsyncer.wait(timeout=300)
+
+            if rsyncer.returncode != 0:
+                buffer_stderr.seek(0)
+                stderr = buffer_stderr.read().decode()
+                message = f"Rsync command failed: {stderr}"
+                logger.error(message)
+                raise ChildProcessError(message)
+
+        else:
+            message = f"Unknown upload target protocol: {self.settings.upload_target}"
+            logger.error(message)
+            raise NotImplementedError(message)

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(name='saraswati',
           "click>=7.1.2,<8",
           "cloup>=0.8.0,<0.9",
           "appdirs>=1.3,<2",
+          "teetime>=0.0.3,<0.1",
       ],
       extras_require={
           "test": [

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -5,7 +5,7 @@ from saraswati.recorder import SaraswatiRecorder
 from saraswati.util import setup_logging
 
 
-def test_spike():
+def test_dryrun():
 
     # Setup logging.
     setup_logging(level=logging.DEBUG)
@@ -19,3 +19,5 @@ def test_spike():
     # Run a basic pipeline test.
     recorder.add_channel(name="channel1", source="audiotestsrc")
     recorder.add_channel(name="channel2", source="audiotestsrc")
+
+    # recorder.play()

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1,0 +1,22 @@
+import logging
+
+from saraswati.model import SaraswatiSettings
+from saraswati.uploader import SaraswatiUploader
+from saraswati.util import setup_logging
+
+
+def test_dryrun():
+
+    # Setup logging.
+    setup_logging(level=logging.DEBUG)
+
+    # Create settings container.
+    settings = SaraswatiSettings(
+        channels=None, upload_target="rsync://foobar@daq.example.org:/tmp/testdrive"
+    )
+
+    # Create uploader.
+    uploader = SaraswatiUploader(settings=settings)
+
+    # Run a basic test.
+    # uploader.upload()


### PR DESCRIPTION
Hi there,

Saraswati is growing up. This patch brings in the following improvements:

- Run recorder in separate thread
- Use 5 minutes recording chunk size as default
- Protect against running out of disk space
    Disk space availability will be checked regularly. When a minimum threshold value is undershot, recording will get suspended. After enough disk space will be free again, the recording will be resumed. By default, disk space checks will run each 60 seconds and will check for a minimum free disk space of 10%.
- Add uploader based on "rsync"
    When the `--upload=` option is given, Saraswati will attempt to upload its spool directory to an rsync target. By default, it will do this each 5 minutes. By using rsync's `--remove-source-files` option, the spooled files on the local machine will get purged after a successful upload.

With kind regards,
Andreas.

/cc @rohlan, @ClemensGruber, @DieDiren 