### PR TITLE
Prepare Saraswati to run as system service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.idea
 /.venv*
+/.vagrant
 /dist
 /var
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,13 @@ in progress
 ===========
 
 
+2021-06-22 0.4.0
+================
+
+- Prepare Saraswati to run as system service. There is now a corresponding
+  command ``sudo saraswati setup --systemd`` which aids this.
+
+
 2021-06-21 0.3.2
 ================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ in progress
 
 - Prepare Saraswati to run as system service. There is now a corresponding
   command ``sudo saraswati setup --systemd`` which aids this.
+-  Emit warning when no audio pipelines are defined
 
 
 2021-06-21 0.3.2

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include setup.cfg *.txt *.rst *.md
 exclude .bumpversion.cfg requirements-*.txt
-recursive-include saraswati *.ini *.py
+recursive-include saraswati *.ini *.py *.default *.service
 prune examples
 prune tests

--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,6 @@ Debian-based systems
     sudo apt-get install --yes libgstreamer1.0 gstreamer1.0-tools gstreamer1.0-alsa gstreamer1.0-plugins-base gstreamer1.0-plugins-good
     sudo apt-get install --yes python3 python3-pip python3-gst-1.0 python3-gi python3-tz
     sudo apt-get install --yes alsa-utils mkvtoolnix flac
-    sudo pip3 install saraswati --upgrade
 
 macOS systems
 -------------

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,18 @@
+Vagrant.configure("2") do |config|
+
+  config.vm.define "saraswati-debian10" do |machine|
+
+    machine.vm.box = "generic/debian10"
+    machine.vm.hostname = 'saraswati-debian10'
+
+    machine.vm.provider :virtualbox do |v|
+      v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+      v.customize ["modifyvm", :id, "--memory", 512]
+      v.customize ["modifyvm", :id, "--name", "saraswati-debian10"]
+    end
+
+    machine.vm.synced_folder ".", "/src"
+
+  end
+
+end

--- a/doc/backlog.rst
+++ b/doc/backlog.rst
@@ -10,12 +10,13 @@ Prio 1
 - [x] Add command line interface
 - [x] Use default chunk size of 5 minutes
 - [x] Upload files and purge from local disk
-- [o] Run as system daemon by using a systemd unit file
+- [x] Run as system daemon by using a systemd unit file
+- [o] Remove testaudio60.wav
+- [o] Improve documentation re. disk storage
 - [o] Document how to use a RAM disk for buffering
 - [o] Document advanced SSH configuration (private key, port number) and write about
       "first-connect" acknowledgements.
       -- https://community.hiveeyes.org/t/developing-saraswati-a-robust-multi-channel-audio-recording-transmission-and-storage-system/924/30
-- [o] Improve documentation re. disk storage
 - [o] What about ``muxer.audio_1``?
 - [o] Record for a maximum number of seconds, using GSt's ``num-buffers=``
 - [o] On Docker, ``Recording suspended: Disk space minimum threshold 10.0% reached`` is quickly reached
@@ -29,6 +30,8 @@ Prio 2
 - [o] PTH - inverted PTT
 - [o] Signaling with MQTT
 - [o] PTH from machine and browser
+  - https://github.com/gdebat/Lossless-Audio-Streamer/blob/master/icecast-autostream.sh
+  - https://community.hiveeyes.org/t/system-fur-kontinuierliche-audio-aufzeichnung-bob-projekt-phase-1/728/17
 - [o] Add support for WavPack
   - https://community.hiveeyes.org/t/developing-saraswati-a-robust-multi-channel-audio-recording-transmission-and-storage-system/924/19
   - https://gstreamer.freedesktop.org/documentation/wavpack/wavpackenc.html

--- a/doc/setup-production.rst
+++ b/doc/setup-production.rst
@@ -1,0 +1,58 @@
+###############################
+Running Saraswati in production
+###############################
+
+
+Configure system
+================
+
+Synchronize system time with NTP, this is important for appropriate timestamping::
+
+    sudo timedatectl set-ntp true
+
+
+Install Saraswati
+=================
+
+Please follow the documentation at https://github.com/hiveeyes/saraswati/tree/0.3.2#install-prerequisites
+in order to install required dependencies. Then, invoke::
+
+    sudo pip3 install saraswati --upgrade
+
+
+
+Install systemd service
+=======================
+
+This will create the system-wide user ``saraswati``, add it to the ``audio``
+user group, and copies the configuration file to ``/etc/default/saraswati``.
+It also installs a systemd unit file to ``/usr/lib/systemd/system/saraswati.service``.
+Afterwards, it will activate and start the service.
+
+The default spool directory, configured in ``/etc/default/saraswati``, is
+``/var/spool/saraswati``.
+
+One-step installation for Linux::
+
+    sudo saraswati setup --systemd
+
+Watch log output::
+
+    journalctl --unit=saraswati --follow
+
+
+Reconfigure settings
+====================
+
+In order to configure more options like adding audio acquisition channels,
+adjusting the upload target, etc., please amend the configuration settings
+within ``/etc/default/saraswati``. After changing them, please restart the
+service using ``systemctl restart saraswati``.
+
+Adding channels will look like::
+
+    SARASWATI_CHANNEL_1="channel1 source=audiotestsrc wave=3 freq=200"
+    SARASWATI_CHANNEL_2="channel2 source=audiotestsrc wave=3 freq=400"
+
+Please note that the suffix to the variable name, ``_1``, ``_2``, will have no
+semantic meaning. It is just to tell different ``CHANNEL`` options apart.

--- a/saraswati/recorder.py
+++ b/saraswati/recorder.py
@@ -93,6 +93,12 @@ class SaraswatiRecorder(threading.Thread):
 
     def play(self):
         success = False
+
+        # TODO: Should this yield an error/exception?
+        if not self.pipelines:
+            logger.warning("No audio pipelines defined")
+            return
+
         for i, pipeline in enumerate(self.pipelines):
             (outcome, state, pending) = pipeline.gst.get_state(timeout=Gst.SECOND)
             if state != Gst.State.PLAYING:

--- a/saraswati/setup/systemd/__init__.py
+++ b/saraswati/setup/systemd/__init__.py
@@ -1,0 +1,49 @@
+import os
+
+import pkg_resources
+
+
+def run():
+
+    # Create user.
+    os.system("groupadd --system saraswati >/dev/null 2>&1")
+    os.system("useradd --system --gid saraswati saraswati >/dev/null 2>&1")
+
+    # Add user to "audio" group.
+    os.system("usermod --append --groups audio saraswati")
+
+    # Fix ACLs on /dev/snd/*
+    # https://askubuntu.com/a/37609
+    os.system("setfacl -m u:saraswati:rw /dev/snd/* >/dev/null 2>&1")
+
+    # Create spool directory.
+    os.system("mkdir -p /var/spool/saraswati")
+    os.system("chown -R saraswati:saraswati /var/spool/saraswati")
+
+    # Copy two files from package to system.
+
+    # Conditionally copy configuration settings blueprint if file does not exist on the system.
+    if os.path.exists("/etc/default/saraswati"):
+        print("WARNING: /etc/default/saraswati already exists, skip copying")
+    else:
+        defaultfile = pkg_resources.resource_filename(
+            "saraswati.setup.systemd", "saraswati.default"
+        )
+        os.system(f"cp {defaultfile} /etc/default/saraswati")
+
+    # Copy systemd unit file. Always.
+    unitfile = pkg_resources.resource_filename(
+        "saraswati.setup.systemd", "saraswati.service"
+    )
+    os.system(f"cp {unitfile} /usr/lib/systemd/system/")
+
+    os.system(
+        "systemctl daemon-reload && systemctl enable saraswati && systemctl restart saraswati"
+    )
+    print()
+    print("Saraswati service started successfully")
+    print()
+
+    print("Start watching logfile using 'journalctl --unit=saraswati --follow'")
+    print()
+    os.system("journalctl --unit=saraswati --follow")

--- a/saraswati/setup/systemd/saraswati.default
+++ b/saraswati/setup/systemd/saraswati.default
@@ -1,0 +1,23 @@
+# ============================
+# Saraswati configuration file
+# ============================
+
+# Location: /etc/default/saraswati
+
+
+# Define audio channels
+
+# SARASWATI_CHANNEL_1="channel1 source=audiotestsrc wave=3 freq=200"
+# SARASWATI_CHANNEL_2="channel2 source=audiotestsrc wave=3 freq=400"
+# SARASWATI_CHANNEL_3="channel3 source=audiotestsrc wave=3 freq=600"
+# SARASWATI_CHANNEL_4="channel4 source=audiotestsrc wave=3 freq=800"
+
+# Configure spool directory
+SARASWATI_SPOOL_PATH=/var/spool/saraswati
+
+# Configure chunking
+# SARASWATI_CHUNK_DURATION=300
+
+# Configure rsync upload
+# SARASWATI_UPLOAD_TARGET="rsync://foobar@daq.example.org:/var/spool/saraswati/testdrive/wp0Kel53aw/area-42/audionode-01"
+# SARASWATI_UPLOAD_INTERVAL=300

--- a/saraswati/setup/systemd/saraswati.service
+++ b/saraswati/setup/systemd/saraswati.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Saraswati multi-channel audio recording system
+Documentation=https://github.com/hiveeyes/saraswati
+After=network.target
+
+[Service]
+User=saraswati
+Group=saraswati
+LimitNOFILE=65536
+EnvironmentFile=-/etc/default/saraswati
+ExecStart=/bin/sh -c "/usr/local/bin/saraswati record"
+KillMode=control-group
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+Alias=saraswati.service

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,10 @@ setup(name='saraswati',
       packages=find_packages(),
       include_package_data=True,
       package_data={
+        'saraswati': [
+            '*.default',
+            '*.service',
+        ],
       },
       zip_safe=False,
       test_suite='tests',


### PR DESCRIPTION
Hi there,

in order to support autonomous operation, this patch prepares Saraswati to be invoked as a systemd service. There is now a corresponding command `sudo saraswati setup --systemd` which aids this. Configuration takes place in `/etc/default/saraswati`.

With kind regards,
Andreas.

/cc @MKO1640, @DieDiren, @ClemensGruber, @rohlan, @wetterfrosch 
