### PR TITLE
Optionally store audio without container; Unlock audio formats wav and wavpack

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Saraswati changelog
 in progress
 ===========
 
+- Add capability for storing audio without putting it into container. Thanks, @MKO1640.
+- Add audio formats "wav" and "WavPack". Thanks, @MKO1640.
+
 2021-07-21 0.6.0
 ================
 
@@ -22,7 +25,7 @@ in progress
 
 - Run recorder service task (checking for free disk space) each 10 seconds
 - Improve production setup documentation
-- Remove ``recording_`` prefix from recorded file name. Thanks, Weef.
+- Remove ``recording_`` prefix from recorded file name. Thanks, @msweef.
 - Improve spool subdirectory hierarchy to reduce the number of files per directory. Thanks, Michael.
   The new scheme is ``/var/spool/saraswati/{year}/{month:02d}/{day:02d}/{channel}/{timestamp}_{channel}_{fragment:04d}.mka``.
 - Use more ISO-like timestamp format, separating each datetime's fragments.

--- a/saraswati/cli.py
+++ b/saraswati/cli.py
@@ -85,9 +85,18 @@ container_opt = click.option(
     "-cf",
     "container_format",
     envvar="CONTAINER_FORMAT",
-    type=click.Choice(["matroska", "ogg"]),
+    type=click.Choice(["matroska", "ogg", "none"]),
     default="matroska",
-    help="""Set container format. Use either "matroska" (default) or "ogg".""",
+    help="""Set container format. Use either "matroska" (default) or "ogg" or "none" for no container.""",
+)
+audio_format_opt = click.option(
+    "--audio-format",
+    "-af",
+    "audio_format",
+    envvar="AUDIO_FORMAT",
+    type=click.Choice(["flac", "wav", "wavpack"]),
+    default="flac",
+    help="""Set audio format. Use either "flac" (default), "wav" or "wavpack".""",
 )
 spool_opt = click.option(
     "--spool",
@@ -182,6 +191,7 @@ def cli(ctx):
 )
 @channels_opt
 @container_opt
+@audio_format_opt
 @spool_opt
 @click.option(
     "--chunk-duration",
@@ -205,6 +215,7 @@ def record(
     chunk_duration: int,
     chunk_max_files: int,
     container_format: str,
+    audio_format: str,
     spool_path: str,
     upload_target: str,
     upload_interval: int,
@@ -228,6 +239,7 @@ def record(
         chunk_duration=chunk_duration,
         chunk_max_files=chunk_max_files,
         container_format=container_format,
+        audio_format=audio_format,
         spool_path=spool_path,
         upload_target=upload_target,
         upload_interval=upload_interval,

--- a/saraswati/model.py
+++ b/saraswati/model.py
@@ -24,7 +24,7 @@ class SaraswatiSettings:
 
     # How to encode the audio.
     container_format: str = "matroska"  # ogg, matroska
-
+    audio_format: str = "flac"          # flac,wav,wavpack
     # Where to store the recordings.
     spool_path: Optional[str] = None
     spool_filename_pattern: Optional[

--- a/saraswati/setup/systemd/saraswati.default
+++ b/saraswati/setup/systemd/saraswati.default
@@ -21,9 +21,15 @@
 # SARASWATI_CHANNEL_12="testdrive3 source=audiotestsrc wave=3 freq=600"
 # SARASWATI_CHANNEL_13="testdrive4 source=audiotestsrc wave=3 freq=800"
 
-# Configure audio recording container
+# Configure audio recording container default=matroska
 # SARASWATI_CONTAINER_FORMAT=matroska
 # SARASWATI_CONTAINER_FORMAT=ogg
+# SARASWATI_CONTAINER_FORMAT=none
+
+# Configure audio recording format. default=flac
+# SARASWATI_AUDIO_FORMAT=flac
+# SARASWATI_AUDIO_FORMAT=wav
+# SARASWATI_AUDIO_FORMAT=wavpack
 
 # Configure spool directory
 SARASWATI_SPOOL_PATH=/var/spool/saraswati


### PR DESCRIPTION
This patch will make it possible to store audio without putting it into any container. At the same time, it will unlock choosing the audio format from either "flac" (default), "wav" or "wavpack".

The patch supersedes #14.